### PR TITLE
Fix relative navigation links and JS paths

### DIFF
--- a/__tests__/caixa.test.js
+++ b/__tests__/caixa.test.js
@@ -1,5 +1,19 @@
 const { salvarLembranca } = require('../js/caixa');
 
+// Simples mock do localStorage para ambiente de testes
+global.localStorage = {
+  store: {},
+  getItem(key) {
+    return this.store[key] || null;
+  },
+  setItem(key, value) {
+    this.store[key] = String(value);
+  },
+  clear() {
+    this.store = {};
+  }
+};
+
 describe('salvarLembranca', () => {
   beforeEach(() => {
     localStorage.clear();

--- a/caixa.html
+++ b/caixa.html
@@ -26,9 +26,9 @@
 
   <section class="bloco frases-poder">
     <p>Algumas coisas não merecem nem saudade. 🧹</p>
-    <a href="../index.html" class="botao-reforco">← Voltar ao Manual</a>
+    <a href="index.html" class="botao-reforco">← Voltar ao Manual</a>
   </section>
 
-  <script src="../js/caixa.js"></script>
+  <script src="js/caixa.js"></script>
 </body>
 </html>

--- a/checklist.html
+++ b/checklist.html
@@ -59,9 +59,9 @@
 
   <section class="bloco frases-poder">
     <p>Quem se ama, não se explica. 💖</p>
-    <a href="../index.html" class="botao-reforco">← Voltar ao Manual</a>
+    <a href="index.html" class="botao-reforco">← Voltar ao Manual</a>
   </section>
 
-  <script src="../js/checklist.js"></script>
+  <script src="js/checklist.js"></script>
 </body>
 </html>

--- a/desculpas.html
+++ b/desculpas.html
@@ -21,9 +21,9 @@
 
   <section class="bloco frases-poder">
     <p>Se precisa de roleta pra justificar, já sabe: lixo reciclável, não emocional ♻️🧠</p>
-    <a href="../index.html" class="botao-reforco">← Voltar ao Manual</a>
+    <a href="index.html" class="botao-reforco">← Voltar ao Manual</a>
   </section>
 
-  <script src="../js/desculpas.js"></script>
+  <script src="js/desculpas.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -105,11 +105,11 @@
   <p>Quer se distrair? Rir? Se lembrar por que você é incrível? <strong>Tem ferramenta pra tudo aqui.</strong></p>
 
   <div class="ferramentas-grid">
-    <a href="/desculpas.html" class="ferramenta-card">💩 Desculpas de ex escroto</a>
-    <a href="/nao-vai-mandar.html" class="ferramenta-card">📵 Mensagens que você NÃO vai mandar</a>
-    <a href="/checklist.html" class="ferramenta-card">🧻 Checklist do nunca mais</a>
-    <a href="/caixa.html" class="ferramenta-card">📦 Caixa do nunca mais</a>
-    <a href="/simulador.html" class="ferramenta-card">🎤 Simulador de DR (onde você vence)</a>
+    <a href="desculpas.html" class="ferramenta-card">💩 Desculpas de ex escroto</a>
+    <a href="nao-vai-mandar.html" class="ferramenta-card">📵 Mensagens que você NÃO vai mandar</a>
+    <a href="checklist.html" class="ferramenta-card">🧻 Checklist do nunca mais</a>
+    <a href="caixa.html" class="ferramenta-card">📦 Caixa do nunca mais</a>
+    <a href="simulador.html" class="ferramenta-card">🎤 Simulador de DR (onde você vence)</a>
   </div>
 
   <p style="margin-top: 30px;">Use o que precisar. Ignore o que não fizer sentido agora. Só não esquece: <strong>você tá sobrevivendo lindamente</strong>.</p>

--- a/nao-vai-mandar.html
+++ b/nao-vai-mandar.html
@@ -22,9 +22,9 @@
 
   <section class="bloco frases-poder">
     <p>Não se explica pra quem não quer entender. 💅</p>
-    <a href="../index.html" class="botao-reforco">← Voltar ao Manual</a>
+    <a href="index.html" class="botao-reforco">← Voltar ao Manual</a>
   </section>
 
-  <script src="../js/nao-vai-mandar.js"></script>
+  <script src="js/nao-vai-mandar.js"></script>
 </body>
 </html>

--- a/simulador.html
+++ b/simulador.html
@@ -23,9 +23,9 @@
 
   <section class="bloco final">
     <p id="mensagemFinal" class="oculto">Você se respeitou. Parabéns, ex-fodona. 💅</p>
-    <a href="../index.html" class="botao-reforco">← Voltar ao Manual</a>
+    <a href="index.html" class="botao-reforco">← Voltar ao Manual</a>
   </section>
 
-  <script src="/js/simulador.js"></script>
+  <script src="js/simulador.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correct tool links in `index.html`
- use relative paths in tool pages for return links and scripts
- add simple localStorage mock for tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6879a5b25d38832ea0b185ffe1105592