### PR TITLE
Add responsive styles for small screens

### DIFF
--- a/css/caixa.css
+++ b/css/caixa.css
@@ -118,3 +118,46 @@ body {
 .sumir {
   animation: desaparecer 0.5s ease forwards;
 }
+
+/* Ajustes responsivos */
+@media (max-width: 768px) {
+  .caixa-form {
+    margin-top: 20px;
+    margin-bottom: 30px;
+  }
+  #lembranca {
+    padding: 16px;
+    font-size: 1rem;
+  }
+  #enterrar {
+    padding: 12px 32px;
+    font-size: 1rem;
+  }
+  #caixaAnimada {
+    width: 120px;
+    height: 80px;
+  }
+  #listaLembrancas li {
+    padding: 12px 16px;
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  #lembranca {
+    padding: 12px;
+    font-size: 0.95rem;
+  }
+  #enterrar {
+    padding: 10px 24px;
+    font-size: 0.95rem;
+  }
+  #caixaAnimada {
+    width: 100px;
+    height: 70px;
+  }
+  #listaLembrancas li {
+    padding: 10px 12px;
+    font-size: 0.95rem;
+  }
+}

--- a/css/checklist.css
+++ b/css/checklist.css
@@ -98,3 +98,35 @@
     60% { transform: scale(1.3);}
     100% { transform: scale(1);}
 }
+
+/* Ajustes responsivos */
+@media (max-width: 768px) {
+    .checklist {
+        padding: 24px 20px;
+        margin: 30px auto;
+    }
+    .checklist li {
+        font-size: 1.1rem;
+        margin-bottom: 18px;
+    }
+    .checklist input[type="checkbox"] {
+        width: 24px;
+        height: 24px;
+        margin-right: 12px;
+    }
+}
+
+@media (max-width: 480px) {
+    .checklist {
+        padding: 20px 16px;
+    }
+    .checklist li {
+        font-size: 1rem;
+        margin-bottom: 16px;
+    }
+    .checklist input[type="checkbox"] {
+        width: 20px;
+        height: 20px;
+        margin-right: 10px;
+    }
+}

--- a/css/desculpas.css
+++ b/css/desculpas.css
@@ -45,3 +45,35 @@
   transform: scale(1.08) rotate(-1deg);
   background: linear-gradient(90deg, #ffb347, #ff3c86);
 }
+
+/* Ajustes responsivos */
+@media (max-width: 768px) {
+  .roleta-container {
+    margin: 30px auto;
+    padding: 16px;
+  }
+  .desculpa {
+    font-size: 1.4rem;
+    padding: 16px 24px;
+  }
+  #botao-girar {
+    font-size: 1.05rem;
+    padding: 10px 22px;
+  }
+}
+
+@media (max-width: 480px) {
+  .roleta-container {
+    margin: 20px auto;
+    padding: 12px;
+  }
+  .desculpa {
+    font-size: 1.2rem;
+    padding: 14px 18px;
+    min-height: 60px;
+  }
+  #botao-girar {
+    font-size: 0.95rem;
+    padding: 8px 18px;
+  }
+}

--- a/css/nao-vai-mandar.css
+++ b/css/nao-vai-mandar.css
@@ -68,3 +68,36 @@
     transform: scale(0.98);
     box-shadow: 0 1px 4px #ff3c8622;
 }
+
+/* Ajustes responsivos */
+@media (max-width: 768px) {
+    .simulador-mensagem label {
+        font-size: 1rem;
+    }
+    .simulador-mensagem textarea {
+        font-size: 1rem;
+        padding: 16px 16px 16px 40px;
+        min-height: 80px;
+        background-position: 12px 16px;
+        background-size: 20px 20px;
+    }
+    .simulador-mensagem .botoes {
+        gap: 10px;
+    }
+    .simulador-mensagem button {
+        padding: 10px 24px;
+        font-size: 1rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .simulador-mensagem textarea {
+        padding: 14px 14px 14px 36px;
+        background-position: 10px 14px;
+        background-size: 18px 18px;
+    }
+    .simulador-mensagem button {
+        padding: 8px 18px;
+        font-size: 0.95rem;
+    }
+}

--- a/css/simulador.css
+++ b/css/simulador.css
@@ -77,3 +77,36 @@
   from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
+/* Ajustes responsivos */
+@media (max-width: 768px) {
+  .simulador-chat {
+    margin: 30px auto;
+    padding: 20px;
+  }
+  .respostas button {
+    font-size: 1rem;
+    padding: 12px 20px;
+  }
+  .final p {
+    font-size: 1.1rem;
+    margin-top: 28px;
+  }
+}
+
+@media (max-width: 480px) {
+  .simulador-chat {
+    margin: 20px auto;
+    padding: 16px;
+  }
+  .mensagem {
+    font-size: 0.95rem;
+  }
+  .respostas button {
+    font-size: 0.95rem;
+    padding: 10px 16px;
+  }
+  .final p {
+    font-size: 1rem;
+  }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -197,13 +197,22 @@ section.bloco {
     to { opacity: 1; transform: translateY(0);}
 }
 
-@media (max-width: 700px) {
+@media (max-width: 768px) {
     h1 { font-size: 2.2rem; }
     h2 { font-size: 1.3rem; }
     p { font-size: 1rem; padding: 0 8px; }
     .botao-rolar, .botao-reforco { font-size: 1rem; padding: 10px 18px; }
     .ferramentas-grid { grid-template-columns: 1fr; }
     .box-visual { padding: 12px; }
+}
+
+@media (max-width: 480px) {
+    h1 { font-size: 2rem; }
+    h2 { font-size: 1.1rem; }
+    p { font-size: 0.95rem; padding: 0 6px; }
+    .botao-rolar, .botao-reforco { font-size: 0.9rem; padding: 8px 14px; }
+    img { max-width: 100px; }
+    .box-visual { padding: 10px; }
 }
 
 img {


### PR DESCRIPTION
## Summary
- tweak main stylesheet breakpoints for tablets and phones
- add responsive helpers for the caixa form
- make checklist more compact on mobile
- reduce roleta layout sizes
- adapt 'não vai mandar' simulator for small screens
- style the DR simulator for narrow displays

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e58367b9c832e9b2a77b83014a78e