### PR TITLE
Implement carta do futuro feature

### DIFF
--- a/carta.html
+++ b/carta.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Carta para o Futuro</title>
+  <link rel="stylesheet" href="./css/style.css">
+  <link rel="stylesheet" href="./css/carta.css">
+</head>
+<body>
+  <section class="hero">
+    <h1>💌 Carta para o Futuro</h1>
+    <p>Escreva para a você do amanhã e volte depois para ler.</p>
+  </section>
+
+  <section class="bloco carta-bloco">
+    <div class="carta-form">
+      <textarea id="carta" placeholder="Escreva sua carta aqui..."></textarea>
+      <button id="enviar">Enviar para o futuro</button>
+    </div>
+    <p id="mensagem" class="oculto"></p>
+    <div id="cartaSalva" class="carta-guardada"></div>
+  </section>
+
+  <section class="bloco frases-poder">
+    <a href="index.html" class="botao-reforco">← Voltar ao Manual</a>
+  </section>
+
+  <script src="js/carta.js"></script>
+</body>
+</html>

--- a/css/carta.css
+++ b/css/carta.css
@@ -1,0 +1,77 @@
+/* Estilos para Carta para o Futuro */
+
+.carta-form {
+  text-align: center;
+  margin: 40px auto;
+}
+
+#carta {
+  width: 90%;
+  max-width: 600px;
+  min-height: 100px;
+  padding: 24px;
+  font-size: 1.1rem;
+  border-radius: 24px;
+  border: 3px solid #ff3c86;
+  background: #fffbe7;
+  box-shadow: 0 4px 16px #ffb34755;
+  outline: none;
+  font-family: 'Comic Neue', cursive;
+  color: #2e1f27;
+}
+
+#enviar {
+  margin-top: 16px;
+  background: linear-gradient(90deg, #ff3c86 0%, #ffb347 100%);
+  color: #fff;
+  padding: 14px 40px;
+  border: none;
+  border-radius: 24px;
+  cursor: pointer;
+  font-family: 'Fredoka One', cursive;
+  font-size: 1.1rem;
+  box-shadow: 0 4px 12px #ffb34755;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+#enviar:hover {
+  transform: scale(1.05);
+  box-shadow: 0 6px 18px #ffb34777;
+}
+
+.carta-guardada, #mensagem {
+  opacity: 0;
+  max-width: 600px;
+  margin: 20px auto;
+  padding: 20px;
+  background: #fff;
+  border: 2px dashed #ff3c86;
+  border-radius: 20px;
+  color: #2e1f27;
+  font-size: 1.2rem;
+  box-shadow: 0 4px 16px #ffb34733;
+}
+
+.mostrar {
+  animation: aparecerCarta 0.6s forwards;
+}
+
+.oculto {
+  display: none;
+}
+
+@keyframes aparecerCarta {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 480px) {
+  #carta {
+    font-size: 1rem;
+    padding: 16px;
+  }
+  #enviar {
+    padding: 12px 28px;
+    font-size: 1rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@
     <a href="checklist.html" class="ferramenta-card">🧻 Checklist do nunca mais</a>
     <a href="caixa.html" class="ferramenta-card">📦 Caixa do nunca mais</a>
     <a href="simulador.html" class="ferramenta-card">🎤 Simulador de DR (onde você vence)</a>
+    <a href="carta.html" class="ferramenta-card">💌 Carta para o futuro</a>
   </div>
 
   <p style="margin-top: 30px;">Use o que precisar. Ignore o que não fizer sentido agora. Só não esquece: <strong>você tá sobrevivendo lindamente</strong>.</p>

--- a/js/carta.js
+++ b/js/carta.js
@@ -1,0 +1,35 @@
+const DELAY_MS = 1000 * 60 * 60 * 24 * 3; // 3 dias
+
+document.addEventListener('DOMContentLoaded', () => {
+  const textarea = document.getElementById('carta');
+  const btn = document.getElementById('enviar');
+  const mensagem = document.getElementById('mensagem');
+  const cartaSalva = document.getElementById('cartaSalva');
+
+  if (btn) {
+    btn.addEventListener('click', () => {
+      const texto = textarea.value.trim();
+      if (!texto) return;
+
+      localStorage.setItem('cartaTexto', texto);
+      localStorage.setItem('cartaTimestamp', Date.now());
+      textarea.value = '';
+      alert('Carta enviada para o futuro!');
+    });
+  }
+
+  const textoSalvo = localStorage.getItem('cartaTexto');
+  const tempoSalvo = parseInt(localStorage.getItem('cartaTimestamp'), 10);
+
+  if (textoSalvo && tempoSalvo && Date.now() - tempoSalvo >= DELAY_MS) {
+    mensagem.textContent =
+      'Olha o que a ex-fodona do passado escreveu pra você \uD83D\uDC8C';
+    mensagem.classList.remove('oculto');
+    mensagem.classList.add('mostrar');
+    cartaSalva.textContent = textoSalvo;
+    cartaSalva.classList.add('mostrar');
+    // opcionalmente limpar armazenamento para não repetir
+    // localStorage.removeItem('cartaTexto');
+    // localStorage.removeItem('cartaTimestamp');
+  }
+});


### PR DESCRIPTION
## Summary
- add new Carta para o Futuro page
- implement carta.js to save letter and reveal it later
- style the new page with carta.css
- link Carta para o Futuro from index

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687fd35a6070832e99741a65d6513051